### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/goci.yml
+++ b/.github/workflows/goci.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           go-version: 1.18
 
-      - uses: golangci/golangci-lint-action@v2
+      - uses: golangci/golangci-lint-action@v9
         with:
           version: v1.45
 


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions for improved features, bug fixes, and security updates.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `golangci/golangci-lint-action` | [`v2`](https://github.com/golangci/golangci-lint-action/releases/tag/v2) | [`v9`](https://github.com/golangci/golangci-lint-action/releases/tag/v9) | [Release](https://github.com/golangci/golangci-lint-action/releases/tag/v9) | goci.yml |

## Why upgrade?

Keeping GitHub Actions up to date ensures:
- **Security**: Latest security patches and fixes
- **Features**: Access to new functionality and improvements
- **Compatibility**: Better support for current GitHub features
- **Performance**: Optimizations and efficiency improvements

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
